### PR TITLE
update rest-client dependency

### DIFF
--- a/accredible-api-ruby.gemspec
+++ b/accredible-api-ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
 
-  s.add_dependency("rest-client", "~> 1.8")
+  s.add_dependency("rest-client", "~> 2.0.2")
 
   s.add_development_dependency("byebug", "~> 8.2")
   s.add_development_dependency("pry", "~> 0.10")


### PR DESCRIPTION
Would it be possible to upgrade the rest-client dependency to 2.0?
https://github.com/rest-client/rest-client#upgrading-to-rest-client-20-from-1x