### PR TITLE
Fix typo in string interpolation

### DIFF
--- a/lib/accredible-api-ruby/credential.rb
+++ b/lib/accredible-api-ruby/credential.rb
@@ -3,7 +3,7 @@ module Accredible
 
     def self.view(id = nil)
       uri = Credential.api_end_point(id)
-      Accredible.request(uri) 
+      Accredible.request(uri)
     end
 
     def self.create(recipient:, credential:, evidence: [], references: [])
@@ -33,7 +33,7 @@ module Accredible
     end
 
     def self.view_all_end_point(group_id, email,page=1,page_size=20)
-      Accredible.api_url("all_credentials?group_id=#{group_id}&email=#{email}&page=#{page}&page_size={page_size}")
+      Accredible.api_url("all_credentials?group_id=#{group_id}&email=#{email}&page=#{page}&page_size=#{page_size}")
     end
   end
 end

--- a/lib/accredible-api-ruby/group.rb
+++ b/lib/accredible-api-ruby/group.rb
@@ -25,7 +25,7 @@ module Accredible
 
     def self.view(group_id = nil)
       uri = Group.api_end_point(group_id)
-      Accredible.request(uri) 
+      Accredible.request(uri)
     end
 
     def self.api_end_point(id = nil)
@@ -34,8 +34,7 @@ module Accredible
 
 
     def self.view_all_end_point(page,page_size)
-      Accredible.api_url("/issuer/all_groups?page=#{page}&page_size={page_size}")
+      Accredible.api_url("/issuer/all_groups?page=#{page}&page_size=#{page_size}")
     end
   end
 end
-


### PR DESCRIPTION
There's a missing `#` in `view_all_end_point` which is causing `Accredible::Credential.view_all(...)` to raise an exception on a 500 because it's generating URIs like:

    https://api.accredible.com/v1/all_credentials?group_id=1&email=me@example.com&page=1&page_size={page_size}

Also found the same typo in `group.rb` (I'm sure one was copied from the other).