### PR TITLE
Fix double slash in group endpoints

### DIFF
--- a/lib/accredible-api-ruby/group.rb
+++ b/lib/accredible-api-ruby/group.rb
@@ -25,17 +25,16 @@ module Accredible
 
     def self.view(group_id = nil)
       uri = Group.api_end_point(group_id)
-      Accredible.request(uri) 
+      Accredible.request(uri)
     end
 
     def self.api_end_point(id = nil)
-      Accredible.api_url("/issuer/groups/#{id}")
+      Accredible.api_url("issuer/groups/#{id}")
     end
 
 
     def self.view_all_end_point(page,page_size)
-      Accredible.api_url("/issuer/all_groups?page=#{page}&page_size={page_size}")
+      Accredible.api_url("issuer/all_groups?page=#{page}&page_size={page_size}")
     end
   end
 end
-


### PR DESCRIPTION
The call to `Accredible.api_url` already ends with a slash so calling it with a string that starts with a slash was creating URLs with 2 slashes in a row. The Accredible webservers seemed to be handling it fine but I can't imagine anyone intended to have two slashes.

Before: 

    Accredible.api_url('/issuer')
    => "https://api.accredible.com/v1//issuer"

After:

    Accredible.api_url('issuer')
    => "https://api.accredible.com/v1/issuer"
